### PR TITLE
Changed respondToSwipe signature

### DIFF
--- a/KSSwipeStack/Classes/SwipableView.swift
+++ b/KSSwipeStack/Classes/SwipableView.swift
@@ -22,15 +22,29 @@ open class SwipableView: UIView {
     }
 
     /**
+     * Is fired when the view is being moved within the stack.
+     * ## You can here change the visuals of the view based on:
+     *   - Whether or not the card is being swiped to the right (liked) or (disliked)
+     *   - The requested opacity of any overlays the view might have, based on the x-position of the view.
+     *
+     * - parameter like: true for like (right) and false for dislike (left)
+     * - parameter opacity: the requested opacity of overlays. Based on x-position
+     */
+    @available(*, deprecated, message: "use respondToSwipe(direction: SwipeDirection, distance: Float) instead")
+    open func respondToSwipe(like: Bool, opacity: Float) {
+    }
+    
+    /**
      Is fired when the view is being moved within the stack.
      ## You can here change the visuals of the view based on:
-        - Whether or not the card is being swiped to the right (liked) or (disliked)
-        - The requested opacity of any overlays the view might have, based on the x-position of the view.
-
-     - parameter like: true for like (right) and false for dislike (left)
-     - parameter opacity: the requested opacity of overlays. Based on x-position
+     - Which direction the card was swiped
+     - How far the card has been swiped from the center of the screen
+     
+     - parameter direction: the SwipeDirection in which the card was swiped
+     - parameter distance: how far away from the center of the sceen the card has been swiped
      */
-    open func respondToSwipe(like: Bool, opacity: Float) {
+    open func respondToSwipe(direction: SwipeDirection, distance: Float) {
+        respondToSwipe(like: direction == .right, opacity: distance)
     }
 
     /**

--- a/KSSwipeStack/Classes/SwipeHelper.swift
+++ b/KSSwipeStack/Classes/SwipeHelper.swift
@@ -59,7 +59,7 @@ class SwipeHelper {
         let rotation = calculateRotationAnimation(cardCenter: toPoint)
         let scale = calculateScaleAnimation(cardCenter: toPoint)
 
-        card.respondToSwipe(like: toPoint.x > 0, opacity: toPoint.equalTo(swipeViewCenter) ? 0.0 : 1.0)
+        card.respondToSwipe(direction: getDirection(toPoint: toPoint), distance: toPoint.equalTo(swipeViewCenter) ? 0.0 : 1.0)
         UIView.animate(withDuration: options.dismissAnimationDuration, delay: 0, options: UIViewAnimationOptions.curveLinear, animations: {
             card.center = toPoint
             card.layer.transform = CATransform3DConcat(rotation, scale)
@@ -67,6 +67,14 @@ class SwipeHelper {
         }, completion: { _ in
             completion()
         })
+    }
+    
+    func getDirection(toPoint: CGPoint) -> SwipeDirection {
+        if abs(toPoint.x) > abs(toPoint.y) {
+            return toPoint.x > 0 ? .right : .left
+        }
+        
+        return toPoint.y > 0 ? .down : .up
     }
 
     /// Calculate the magnitude if a throw based on the velocity vector

--- a/KSSwipeStack/Classes/SwipeView.swift
+++ b/KSSwipeStack/Classes/SwipeView.swift
@@ -219,8 +219,8 @@ public class SwipeView: UIView {
             card.center = CGPoint(x: frame.width / 2 + translation.x, y: frame.height / 2 + translation.y)
             swipeHelper.transformCard(card)
 
-            let opacity = abs(Float(card.center.x.distance(to: self.center.x) / (frame.width / 4)))
-            card.respondToSwipe(like: translation.x > 0, opacity: opacity)
+            let distance = abs(Float(card.center.x.distance(to: self.center.x) / (frame.width / 4)))
+            card.respondToSwipe(direction: translation.x > 0 ? .right : .left, distance: distance)
 
             if gesture.state == .ended {
                 let throwingThresholdExceeded = magnitude > options.throwingThreshold
@@ -260,8 +260,8 @@ public class SwipeView: UIView {
             card.center = CGPoint(x: frame.width / 2 + translation.x, y: frame.height / 2 + translation.y)
             swipeHelper.transformCard(card)
 
-            let opacity = abs(Float(card.center.y.distance(to: self.center.y) / (frame.height / 4)))
-            card.respondToSwipe(like: translation.y > 0, opacity: opacity)
+            let distance = abs(Float(card.center.y.distance(to: self.center.y) / (frame.height / 4)))
+            card.respondToSwipe(direction: translation.y > 0 ? .down : .up, distance: distance)
 
             if gesture.state == .ended {
                 let throwingThresholdExceeded = magnitude > options.throwingThreshold


### PR DESCRIPTION
Made respondToSwipe more useable by passing it the direction (and not just a boolean), and thus enabling it to differentiate between vertical and horizontal swipes. Also changed the parameter name opacity (which was a remain from the legacy project in which KSSwipeStack was first used) to distance.